### PR TITLE
Add anchored container example, handle starting style

### DIFF
--- a/matchContainer.js
+++ b/matchContainer.js
@@ -48,7 +48,12 @@
         inherits: false;
         initial-value: --false;
       }
-      @container ${containerQueryString} { [${markerAttribute}] { ${sentinelProperty}: --true; } }`;
+      @container ${containerQueryString} { [${markerAttribute}] { ${sentinelProperty}: --true; } }
+      [${markerAttribute}]{
+        @starting-style{
+          ${sentinelProperty}: --unknown; 
+        }
+      }`;
 
       containerQuerySheet.replaceSync(css);
       document.adoptedStyleSheets = [

--- a/test/anchored.html
+++ b/test/anchored.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="../matchContainer.js"></script>
+
+    <style>
+      body {
+        display: grid;
+        height: 200vh;
+        place-items: center;
+        --radius: 10px;
+        --border-start: var(--radius) var(--radius) 0 0;
+        --border-end: 0 0 var(--radius) var(--radius);
+      }
+      select {
+        &,
+        &::picker(select) {
+          appearance: base-select;
+          min-width: 30ch;
+        }
+        & {
+          border-radius: var(--border-start);
+        }
+        &:not(:open) {
+          border-radius: var(--radius);
+        }
+        &.matches {
+          border-radius: var(--border-end);
+          &:not(:open) {
+            border-radius: var(--radius);
+          }
+          &::picker(select) {
+            border-radius: var(--border-start);
+          }
+        }
+        &::picker(select) {
+          border-radius: var(--border-end);
+          position-area: bottom;
+          position-try: flip-block;
+          min-block-size: max-content;
+          container-type: anchored;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <select>
+      <button>
+        <div>
+          <selectedcontent> </selectedcontent>
+        </div>
+      </button>
+      <div>
+        <option value="carrot">Captain Carrot</option>
+        <option value="garlick">Magrat Garlick</option>
+        <option value="dibbler">Cut-Me-Own-Throat Dibbler</option>
+      </div>
+    </select>
+    <script>
+      const watchingEl = document.querySelector('[value="carrot"]');
+      const select = document.querySelector("select");
+
+      const positionedElementQuery = watchingEl.matchContainer(
+        "anchored(fallback: flip-block)",
+      );
+
+      const onPositionedElementChanged = (event) => {
+        console.count('switch')
+        if (event.matches) {
+          select.classList.add("matches");
+        } else {
+          select.classList.remove("matches");
+        }
+      };
+
+      positionedElementQuery.addEventListener(
+        "change",
+        onPositionedElementChanged,
+      );
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Thanks for the polyfill! 

I was curious if `anchored(fallback)` container queries [(spec)](https://drafts.csswg.org/css-anchor-position-2) would be supported with this polyfill. It appears they are, and I added an example with a Custom Select. 

I added a `@starting-style` rule so that changes while a popover is closed (as is the case with many `position-try-fallbacks` use cases) trigger events. This means the check will always trigger when the observed element goes from hidden to displayed, but it still will only trigger a change event if it opens in a different state.

The example is very much tied to my use case - if you'd like an example that more clearly shows when the match is applied, let me know. 