### PR TITLE
Fix unregistered global TS types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -14,4 +14,4 @@ declare global {
   }
 }
 
-declare module "match-container" {}
+export {};


### PR DESCRIPTION
Greetings,

currently the global TS types declarations are not registered properly, leading to errors. 
Reproduction: https://stackblitz.com/edit/node-avutvgsa?file=index.ts

The issue is that a `declare global` in a `.d.ts` file requires the file to be treated as a module to work. If the file has no imports or exports, TypeScript treats it as a script (global scope) and `declare global` is invalid/ignored in that context.

Added an `export {}` at the bottom to make it a module.


